### PR TITLE
Solve error typing 0.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 tab_width = 2
 end_of_line = lf
 insert_final_newline = true

--- a/js/index.js
+++ b/js/index.js
@@ -64,9 +64,11 @@ const handleNumberClick = number => {
 
   if (number === '.' && currentOperation.displayValue.includes('.')) return
 
-  currentOperation.displayValue = currentOperation.displayValue === '0' || (currentOperation.operator !== null && currentOperation.secondNumber === 0)
+  currentOperation.displayValue = currentOperation.operator !== null && currentOperation.secondNumber === 0 && currentOperation.displayValue !== '0.'
     ? number
     : screenValue + number
+
+  if (currentOperation.displayValue === '.') currentOperation.displayValue = '0.'
 
   if (currentOperation.operator === null) {
     currentOperation.firstNumber = Number(currentOperation.displayValue)
@@ -125,8 +127,18 @@ const getScreenValue = () => {
 }
 
 const updateScreen = () => {
+  console.log(currentOperation)
+
+  const newValue = Number(currentOperation.displayValue)
+
+  if (isNaN(newValue)) return displayError()
+
   screen.textContent = Number(currentOperation.displayValue).toLocaleString('en', { maximumFractionDigits: 10 })
   if (currentOperation.displayValue.slice(-1) === '.') screen.textContent += '.'
+}
+
+const displayError = () => {
+  screen.textContent = 'ERROR!'
 }
 
 const init = () => {

--- a/js/index.js
+++ b/js/index.js
@@ -127,8 +127,6 @@ const getScreenValue = () => {
 }
 
 const updateScreen = () => {
-  console.log(currentOperation)
-
   const newValue = Number(currentOperation.displayValue)
 
   if (isNaN(newValue)) return displayError()


### PR DESCRIPTION
Fix #10.

Prevent eval `0.` with `Number.toLocaleString()`.

Show `ERROR!` on display if the result is `NaN`.

Fix `.editorconfig` setting `indent_style = space` to follow the standardjs guidelines.